### PR TITLE
Implement init wizard and status, show rclone version

### DIFF
--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -1,3 +1,14 @@
+use dialoguer::Input;
+
+use crate::core::rclone;
+
 pub fn init_wizard() {
-    println!("Running setup wizard (not yet implemented)");
+    println!("Starting rclone configuration wizard...");
+
+    let remote_name: String = Input::new()
+        .with_prompt("Enter a name for your remote")
+        .interact_text()
+        .unwrap_or_else(|_| "drive".into());
+
+    let _ = rclone::run_rclone(&["config", "create", remote_name.as_str(), "drive"]);
 }

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -9,5 +9,6 @@ pub fn mount() {
 }
 
 pub fn status() {
-    println!("Status feature not implemented yet");
+    println!("Configured rclone remotes:");
+    let _ = rclone::run_rclone(&["listremotes"]);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 use crate::config::setup::init_wizard;
 use crate::core::sync::{sync, mount, status};
+use crate::core::rclone;
 
 mod config {
     pub mod setup;
@@ -36,6 +37,11 @@ fn main() {
         Commands::Sync => sync(),
         Commands::Mount => mount(),
         Commands::Status => status(),
-        Commands::Version => println!("gsync {}", env!("CARGO_PKG_VERSION")),
+        Commands::Version => {
+            println!("gsync {}", env!("CARGO_PKG_VERSION"));
+            if let Err(e) = rclone::run_rclone(&["--version"]) {
+                eprintln!("Failed to get rclone version: {e}");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add interactive `init` wizard that creates a Drive remote via rclone
- implement `status` command to list configured remotes
- show rclone version alongside gsync version

## Testing
- `cargo test`
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68419aecc34c832dbaff2fbdb58e1417